### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
   - create an index displaying all hog tiles
     - render each hog name and picture in a tile, and show the hog's details upon a user's click
   - allow users to sort the hogs based on name and weight, and filter the hogs that are greased
-  - BONUS: display a Hog image in your index––this is fairly complex so save it for later!
   - BONUS: allow users to hide hogs (not delete them, just hide them from view!)
   - BONUS: bring in pig gifs from an API
   - BONUS: implement [Semantic Cards](https://semantic-ui.com/views/card.html) for each hog


### PR DESCRIPTION
Deleting the bonus saying to add the pictures to the index because of the original requirement already requiring the picture in the tile.

render each hog name and picture in a tile, and show the hog's details upon a user's click

